### PR TITLE
Add support for adopting a seahorse.

### DIFF
--- a/pets/agency_sync.py
+++ b/pets/agency_sync.py
@@ -98,6 +98,13 @@ class AgencySync:
             yield "Since 2015 the brontasaurus and apatosaurus have been recognised as separate species. Would you like to adopt a brontasaurus?"
             return
 
+        if pet_type == "seahorse":
+            try:
+                pet = random.choice(list(self.pet_directory.available()))
+                pet.bot_json["name"] = "seahorse"
+            except IndexError:
+                yield "You already have too many seahorses."
+                return
         if pet_type == "surprise" or pet_type == "mystery":
             if not self.pet_directory.mystery_pets:
                 yield "Sorry, we don't have any mystery boxes at the moment."

--- a/pets/agency_sync.py
+++ b/pets/agency_sync.py
@@ -105,7 +105,7 @@ class AgencySync:
             except IndexError:
                 yield "You already have too many seahorses."
                 return
-        if pet_type == "surprise" or pet_type == "mystery":
+        elif pet_type == "surprise" or pet_type == "mystery":
             if not self.pet_directory.mystery_pets:
                 yield "Sorry, we don't have any mystery boxes at the moment."
                 return

--- a/tests/test_pets.py
+++ b/tests/test_pets.py
@@ -251,6 +251,29 @@ async def test_successful_adopt_at_random(genie, rocket, person):
 
 
 @pytest.mark.asyncio
+async def test_successful_seahorse_adoption(genie, rocket, person):
+    session = MockSession({"bots": [genie, rocket]})
+
+    async with await Agency.create(session) as agency:
+        await agency.handle_entity(
+            incoming_message(person, genie, "adopt a seahorse, please!")
+        )
+
+    assert await session.message_received(rocket, person) == NOISES["🚀"]
+
+    request = await session.get_request()
+
+    assert request == Request(
+        method="patch",
+        path="bots",
+        id=rocket["id"],
+        json={"bot": {"name": f"{person['person_name']}'s seahorse"}},
+    )
+
+    assert is_adjacent(person["pos"], await session.moved_to())
+
+
+@pytest.mark.asyncio
 async def test_successful_abandonment(genie, owned_cat, person):
     session = MockSession({"bots": [genie, owned_cat]})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now adopt a seahorse. The adopted pet is named “{your name}’s seahorse” and participates in adoption interactions like other pets.
  * If you’ve reached the seahorse limit, you’ll see: “You already have too many seahorses.”

* **Tests**
  * Added tests validating the seahorse adoption flow and related interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->